### PR TITLE
draw feature bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ The original project is from [React Docs](https://react.dev/learn/tutorial-tic-t
 
 ### (under-development)
 
-1. For the current move only, show "You are at move #..." instead of a button
-2. Rewrite Board to use two loops to make the squares instead of hardcoding them
-3. Add a toggle button that lets you sort the moves in either ascending or descending order
-4. When someone wins, highlight the three squares that caused the win (and when no one wins, display a message about the result being a draw)
+1. For the current move only, show "You are at move #..." instead of a button ✅
+2. Rewrite Board to use two loops to make the squares instead of hardcoding them ✅
+3. Add a toggle button that lets you sort the moves in either ascending or descending order ✅
+4. When someone wins, highlight the three squares that caused the win (and when no one wins, display a message about the result being a draw) ✅
 5. Display the location for each move in the format(row,col) in the move history list
 
 ## Links

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -70,16 +70,18 @@ export default function Board({ xIsNext, squares, onPlay }) {
 
   // if there is a winner value
   // status will take on the value
+  // * REFACTORED
+  // * If every square has a value and does not produce a any winner values `status` = "Draw"
   // if there is no current winner
   // status will will take on the value of the current player based on state `xisNext`
   if (winner) {
     status = "Winner: " + winner;
+  } else if (squares.every((square) => square !== null)) {
+    status = "Draw";
   } else {
     status = "Next player: " + (xIsNext ? "🍙" : "🍘");
   }
 
-  // TODO: When someone wins, highlight the three squares that caused the win
-  // TODO: When no one wins, display a message about result being a draw
   // TODO: Display the location for each move in the format(row,col) in the move history list
 
   // Generate 3x3 board of Square components

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -50,13 +50,13 @@ export default function Game() {
   // Sort moves based on sorting order
   const sortedMoves = isMovesAscending ? moves : moves.slice().reverse();
 
-  const isDrawGame = moves.length > 9 ? <h3 className="draw">draw</h3> : "";
+  // ! BUG: If player wins in 9 moves the DRAW message appears DO NOT USE
+  // const isDrawGame = moves.length > 9 ? <h3 className="draw">draw</h3> : "";
 
   return (
     <div className="game">
       <div className="game-board">
         <Board xIsNext={xIsNext} squares={currentSquares} onPlay={handlePlay} />
-        {isDrawGame}
       </div>
       <div className="game-info">
         <button


### PR DESCRIPTION
- BUG:  if a player wins in 9 moves the "draw" message appears
- FIXED: in the state `squares` if the square components do not have a winning condition and ALL square components contain a value `status` will produce the message "draw"